### PR TITLE
Size in units mvp 2

### DIFF
--- a/ydb/core/blobstorage/incrhuge/incrhuge_keeper.cpp
+++ b/ydb/core/blobstorage/incrhuge/incrhuge_keeper.cpp
@@ -28,6 +28,7 @@ namespace NKikimr {
         void TKeeper::Bootstrap(const TActorContext& ctx) {
             // send yard init message
             TVDiskID myVDiskId(TGroupId::FromValue(~0), ~0, 'H', 'I', 'K');
+            // TODO(ydynnikov): revise SlotSizeInUnits=0 in TEvYardInit
             ctx.Send(State.Settings.PDiskActorId, new NPDisk::TEvYardInit(State.Settings.InitOwnerRound, myVDiskId,
                     State.Settings.PDiskGuid, ctx.SelfID));
             Become(&TKeeper::StateFunc);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -139,16 +139,24 @@ struct TEvYardInit : TEventLocal<TEvYardInit, TEvBlobStorage::EvYardInit> {
     TActorId CutLogID; // ask this actor about log cut
     TActorId WhiteboardProxyId;
     ui32 SlotId;
+    ui32 GroupSizeInUnits;
 
-    TEvYardInit(TOwnerRound ownerRound, const TVDiskID &vdisk, ui64 pDiskGuid,
-            const TActorId &cutLogID = TActorId(), const TActorId& whiteboardProxyId = {},
-            ui32 slotId = Max<ui32>())
+    TEvYardInit(
+            TOwnerRound ownerRound,
+            const TVDiskID &vdisk,
+            ui64 pDiskGuid,
+            const TActorId &cutLogID = TActorId(),
+            const TActorId& whiteboardProxyId = {},
+            ui32 slotId = Max<ui32>(),
+            ui32 groupSizeInUnits = 0
+        )
         : OwnerRound(ownerRound)
         , VDisk(vdisk)
         , PDiskGuid(pDiskGuid)
         , CutLogID(cutLogID)
         , WhiteboardProxyId(whiteboardProxyId)
         , SlotId(slotId)
+        , GroupSizeInUnits(groupSizeInUnits)
     {}
 
     TString ToString() const {
@@ -162,6 +170,8 @@ struct TEvYardInit : TEventLocal<TEvYardInit, TEvBlobStorage::EvYardInit> {
         str << " PDiskGuid# " << record.PDiskGuid;
         str << " CutLogID# " << record.CutLogID;
         str << " WhiteboardProxyId# " << record.WhiteboardProxyId;
+        str << " SlotId# " << record.SlotId;
+        str << " GroupSizeInUnits# " << record.GroupSizeInUnits;
         str << "}";
         return str.Str();
     }
@@ -239,11 +249,12 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
     }
 };
 
-struct TEvLogResult;
 
 ////////////////////////////////////////////////////////////////////////////
 // LOG
 ////////////////////////////////////////////////////////////////////////////
+struct TEvLogResult;
+
 struct TEvLog : TEventLocal<TEvLog, TEvBlobStorage::EvLog> {
     struct ICallback {
         virtual ~ICallback() = default;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -52,31 +52,50 @@ public:
         RedistributeQuotas();
     }
 
+    size_t GetNumActiveSlots() {
+        size_t sum = 0;
+        for (TOwner id: ActiveOwnerIds) {
+            sum += QuotaForOwner[id].GetWeight();
+        }
+        return sum;
+    }
+
     i64 ForceHardLimit(TOwner ownerId, i64 limit) {
         Y_VERIFY(limit >= 0);
         return QuotaForOwner[ownerId].ForceHardLimit(limit, ColorLimits);
     }
 
     void RedistributeQuotas() {
-        size_t parts = Max(ExpectedOwnerCount, ActiveOwnerIds.size());
+        size_t parts = Max(ExpectedOwnerCount, GetNumActiveSlots());
         if (parts) {
             i64 limit = Total / parts;
 
             // Divide into equal parts and that's it.
             for (TOwner id : ActiveOwnerIds) {
-                ForceHardLimit(id, limit);
+                auto weight = QuotaForOwner[id].GetWeight();
+                ForceHardLimit(id, limit * weight);
             }
         }
     }
 
-    void AddOwner(TOwner id, TVDiskID vdiskId) {
+    void AddOwner(TOwner id, TVDiskID vdiskId, ui32 weight) {
         TQuotaRecord &record = QuotaForOwner[id];
         Y_VERIFY(record.GetHardLimit() == 0);
         Y_VERIFY(record.GetFree() == 0);
         record.SetName(TStringBuilder() << "Owner# " << id);
         record.SetVDiskId(vdiskId);
+        record.SetWeight(weight);
 
         ActiveOwnerIds.push_back(id);
+        RedistributeQuotas();
+    }
+
+    void SetOwnerWeight(TOwner id, ui32 weight) {
+        auto it = std::find(ActiveOwnerIds.begin(), ActiveOwnerIds.end(), id);
+        Y_VERIFY(it != ActiveOwnerIds.end());
+
+        TQuotaRecord &record = QuotaForOwner[id];
+        record.SetWeight(weight);
         RedistributeQuotas();
     }
 
@@ -146,6 +165,7 @@ public:
         str << "<td>" << q.GetHardLimit() << "</td>";
         str << "<td>" << q.GetFree() << "</td>";
         str << "<td>" << q.GetUsed() << "</td>";
+        str << "<td>" << q.GetWeight() << "</td>";
         double occupancy;
         str << "<td>" << NKikimrBlobStorage::TPDiskSpaceColor::E_Name(q.EstimateSpaceColor(0, &occupancy)) << "</td>";
         str << "<td>" << occupancy << "</td>";
@@ -167,6 +187,7 @@ public:
         str << "\nTotal# " << Total;
         str << "\nExpectedOwnerCount# " << ExpectedOwnerCount;
         str << "\nActiveOwners# " << ActiveOwnerIds.size();
+        str << "\nNumActiveSlots# " << GetNumActiveSlots();
         if (colorBorder) {
             str << "\nColorBorder# " << NKikimrBlobStorage::TPDiskSpaceColor::E_Name(*colorBorder);
         }
@@ -182,6 +203,7 @@ public:
                 <th>HardLimit</th>
                 <th>Free</th>
                 <th>Used</th>
+                <th>Weight</th>
                 <th>Color</th>
                 <th>Occupancy</th>
 
@@ -313,7 +335,7 @@ public:
 
         for (auto& [ownerId, ownerInfo] : params.OwnersInfo) {
             i64 chunks = ownerInfo.ChunksOwned;
-            AddOwner(ownerId, ownerInfo.VDiskId);
+            AddOwner(ownerId, ownerInfo.VDiskId, ownerInfo.Weight);
             if (chunks) {
                 OwnerQuota->InitialAllocate(ownerId, chunks);
                 bool isOk = SharedQuota->InitialAllocate(chunks);
@@ -343,14 +365,23 @@ public:
         return true;
     }
 
-    void AddOwner(TOwner owner, TVDiskID vdiskId) {
+    void AddOwner(TOwner owner, TVDiskID vdiskId, ui32 weight = 1) {
         Y_VERIFY(IsOwnerUser(owner));
-        OwnerQuota->AddOwner(owner, vdiskId);
+        OwnerQuota->AddOwner(owner, vdiskId, weight);
+    }
+
+    void SetOwnerWeight(TOwner owner, ui32 weight) {
+        Y_VERIFY(IsOwnerUser(owner));
+        OwnerQuota->SetOwnerWeight(owner, weight);
     }
 
     void RemoveOwner(TOwner owner) {
         Y_VERIFY(IsOwnerUser(owner));
         OwnerQuota->RemoveOwner(owner);
+    }
+
+    ui32 GetNumActiveSlots() const {
+        return OwnerQuota->GetNumActiveSlots();
     }
 
     i64 GetOwnerHardLimit(TOwner owner) const {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -431,6 +431,15 @@ struct TPDiskConfig : public TThrRefBase {
         }
     }
 
+    ui32 GetOwnerWeight(ui32 groupSizeInUnits) {
+        return TPDiskConfig::GetOwnerWeight(groupSizeInUnits, SlotSizeInUnits);
+    }
+
+    static ui32 GetOwnerWeight(ui32 groupSizeInUnits, ui32 slotSizeInUnits) {
+        ui32 vu = groupSizeInUnits ?: 1;
+        ui32 pu = slotSizeInUnits ?: 1;
+        return int(vu / pu) + !!(vu % pu);
+    }
 };
 
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
@@ -49,6 +49,7 @@ constexpr ui32 SmallDiskMaximumChunkSize = 32 * (1 << 20); // 32MB
 // #define PDISK_SYS_LOG_RECORD_VERSION_5 5 // It was used in reverted commits, just avoid this version
 #define PDISK_SYS_LOG_RECORD_VERSION_6 6
 #define PDISK_SYS_LOG_RECORD_VERSION_7 7
+#define PDISK_SYS_LOG_RECORD_VERSION_8 8
 #define PDISK_SYS_LOG_RECORD_INCOMPATIBLE_VERSION_1000 1000
 #define FORMAT_TEXT_SIZE 1024
 
@@ -341,7 +342,7 @@ struct TSysLogRecord {
     TVDiskID OwnerVDisks[256];
 
     TSysLogRecord()
-        : Version(PDISK_SYS_LOG_RECORD_VERSION_7)
+        : Version(PDISK_SYS_LOG_RECORD_VERSION_8)
         , LogHeadChunkIdx(0)
         , Reserved1(0)
         , LogHeadChunkPreviousNonce((ui64)-1)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.h
@@ -280,6 +280,7 @@ public:
     ui32 GetTotalChunks(ui32 ownerId, const EOwnerGroupType ownerGroupType) const;
     ui32 GetFreeChunks(ui32 ownerId, const EOwnerGroupType ownerGroupType) const;
     ui32 GetUsedChunks(ui32 ownerId, const EOwnerGroupType ownerGroupType) const;
+    ui32 GetNumActiveSlots() const;
     TStatusFlags GetStatusFlags(TOwner ownerId, const EOwnerGroupType ownerGroupType, double *occupancy = nullptr) const;
     TStatusFlags NotEnoughDiskSpaceStatusFlags(ui32 ownerId, const EOwnerGroupType ownerGroupType) const;
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_http.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_http.cpp
@@ -302,6 +302,7 @@ void TPDisk::OutputHtmlOwners(TStringStream &str) {
                 TABLER() {
                     TABLEH() { str << "OwnerId";}
                     TABLEH() { str << "VDiskId"; }
+                    TABLEH() { str << "GroupSizeInUnits"; }
                     TABLEH() { str << "ChunksOwned"; }
                     TABLEH() { str << "CutLogId"; }
                     TABLEH() { str << "WhiteboardProxyId"; }
@@ -322,6 +323,7 @@ void TPDisk::OutputHtmlOwners(TStringStream &str) {
                         TABLER() {
                             TABLED() { str << (ui32) owner;}
                             TABLED() { str << data.VDiskId.ToStringWOGeneration() << "<br/>(" << data.VDiskId.GroupID << ")"; }
+                            TABLED() { str << data.GroupSizeInUnits; }
                             TABLED() { str << chunksOwned[owner]; }
                             TABLED() { str << data.CutLogId.ToString(); }
                             TABLED() { str << data.WhiteboardProxyId; }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
@@ -58,8 +58,12 @@ public:
     // Add/remove owner
     //
 
-    void AddOwner(TOwner owner, TVDiskID vdiskId) {
-        ChunkTracker.AddOwner(owner, vdiskId);
+    void AddOwner(TOwner owner, TVDiskID vdiskId, ui32 weight) {
+        ChunkTracker.AddOwner(owner, vdiskId, weight);
+    }
+
+    void SetOwnerWeight(TOwner owner, ui32 weight) {
+        ChunkTracker.SetOwnerWeight(owner, weight);
     }
 
     void RemoveOwner(TOwner owner) {
@@ -91,6 +95,10 @@ public:
 
     i64 GetLogChunkCount() const {
         return ChunkTracker.GetLogChunkCount();
+    }
+
+    ui32 GetNumActiveSlots() const {
+        return ChunkTracker.GetNumActiveSlots();
     }
 
     TChunkIdx PopOwnerFreeChunk(TOwner owner, TString &outErrorReason) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper_params.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper_params.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "defs.h"
+#include <ydb/core/blobstorage/base/blobstorage_vdiskid.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h>
+#include <ydb/core/protos/blobstorage_disk_color.pb.h>
 
 #include <util/generic/map.h>
 
@@ -15,6 +17,7 @@ namespace NPDisk {
 struct TOwnerInfo {
     i64 ChunksOwned;
     TVDiskID VDiskId;
+    ui32 Weight;
 };
 
 struct TKeeperParams {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_quota_record.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_quota_record.h
@@ -3,6 +3,8 @@
 #include "blobstorage_pdisk_defs.h"
 #include "blobstorage_pdisk_color_limits.h"
 
+#include <ydb/core/blobstorage/base/blobstorage_vdiskid.h>
+
 namespace NKikimr {
 namespace NPDisk {
 
@@ -34,6 +36,7 @@ class TQuotaRecord {
 
     TString Name;
     std::optional<TVDiskID> VDiskId;
+    ui32 Weight = 1;
 public:
     void SetName(const TString& name) {
         Name = name;
@@ -41,6 +44,10 @@ public:
 
     void SetVDiskId(const TVDiskID& v) {
         VDiskId = v;
+    }
+
+    void SetWeight(ui32 v) {
+        Weight = v;
     }
 
     i64 GetUsed() const {
@@ -53,6 +60,10 @@ public:
 
     i64 GetFree() const {
         return AtomicGet(Free);
+    }
+
+    ui32 GetWeight() const {
+        return Weight ?: 1;
     }
 
     TString Print() const {
@@ -70,6 +81,7 @@ public:
         str << " HardLimit# " << HardLimit;
         str << " Free# " << Free;
         str << " Used# " << GetUsed();
+        str << " Weight# " << GetWeight();
         double occupancy;
         str << " CurrentColor# " << NKikimrBlobStorage::TPDiskSpaceColor::E_Name(EstimateSpaceColor(0, &occupancy)) << "\n";
         str << " Occupancy# " << occupancy << "\n";

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_requestimpl.h
@@ -131,6 +131,7 @@ public:
     TActorId CutLogId;
     TActorId WhiteboardProxyId;
     ui32 SlotId;
+    ui32 GroupSizeInUnits;
 
     TYardInit(const NPDisk::TEvYardInit &ev, const TActorId &sender, TAtomicBase reqIdx)
         : TRequestBase(sender, TReqId(TReqId::YardInit, reqIdx), 0, ev.OwnerRound, NPriInternal::Other)
@@ -139,6 +140,7 @@ public:
         , CutLogId(ev.CutLogID)
         , WhiteboardProxyId(ev.WhiteboardProxyId)
         , SlotId(ev.SlotId)
+        , GroupSizeInUnits(ev.GroupSizeInUnits)
     {}
 
     ERequestType GetType() const override {
@@ -157,6 +159,7 @@ public:
         str << "VDisk# " << VDisk.ToString();
         str << " PDiskGuid# " << PDiskGuid;
         str << " SlotId# " << SlotId;
+        str << " GroupSizeInUnits# " << GroupSizeInUnits;
         str << "}";
         return str.Str();
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_state.h
@@ -94,6 +94,7 @@ struct TOwnerData {
     NMetrics::TDecayingAverageValue<ui64, NMetrics::DurationPerMinute, NMetrics::DurationPerSecond> ReadThroughput;
     NMetrics::TDecayingAverageValue<ui64, NMetrics::DurationPerMinute, NMetrics::DurationPerSecond> WriteThroughput;
     ui32 VDiskSlotId = 0;
+    ui32 GroupSizeInUnits = 0;
 
     TIntrusivePtr<TLogReaderBase> LogReader;
     TIntrusivePtr<TOwnerInflight> InFlight;
@@ -211,6 +212,7 @@ struct TOwnerData {
             str << " HasReadTheWholeLog";
         }
         str << " VDiskSlotId# " << VDiskSlotId;
+        str << " SizeInUnits# " << GroupSizeInUnits;
         if (InFlight) {
             str << " Inflight {";
             str << " ChunkWrites# " << InFlight->ChunkWrites.load();
@@ -244,6 +246,7 @@ struct TOwnerData {
         ReadThroughput = NMetrics::TDecayingAverageValue<ui64, NMetrics::DurationPerMinute, NMetrics::DurationPerSecond>();
         WriteThroughput = NMetrics::TDecayingAverageValue<ui64, NMetrics::DurationPerMinute, NMetrics::DurationPerSecond>();
         VDiskSlotId = 0;
+        GroupSizeInUnits = 0;
 
         if (!quarantine) {
             LogReader.Reset();

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_pdisk_config.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_pdisk_config.cpp
@@ -1,0 +1,54 @@
+#include "blobstorage_pdisk_chunk_tracker.h"
+#include "blobstorage_pdisk_color_limits.h"
+
+#include "blobstorage_pdisk_ut.h"
+#include "blobstorage_pdisk_ut_actions.h"
+#include "blobstorage_pdisk_ut_helpers.h"
+#include "blobstorage_pdisk_ut_run.h"
+
+#include <ydb/core/testlib/actors/test_runtime.h>
+
+namespace NKikimr {
+
+Y_UNIT_TEST_SUITE(TPDiskConfig) {
+
+    Y_UNIT_TEST(GetOwnerWeight) {
+        using namespace NPDisk;
+        using namespace NKikimrBlobStorage;
+
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(0, 0), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(1, 0), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(2, 0), 2);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(3, 0), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(4, 0), 4);
+
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(0, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(1, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(2, 1), 2);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(3, 1), 3);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(4, 1), 4);
+
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(0, 2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(1, 2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(2, 2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(3, 2), 2);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(4, 2), 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(0, 4), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(1, 4), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(2, 4), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(3, 4), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(4, 4), 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(5, 3), 2);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(99, 100), 1);
+        UNIT_ASSERT_VALUES_EQUAL(TPDiskConfig::GetOwnerWeight(101, 100), 2);
+
+        TPDiskConfig pdiskConfig3u(0, 0, 0);
+        pdiskConfig3u.SlotSizeInUnits = 3;
+        UNIT_ASSERT_VALUES_EQUAL(pdiskConfig3u.GetOwnerWeight(10), 4);
+
+        // TODO(ydynnikov): test the case of groupSizeInUnits > UI8_MAX (255)
+    }
+}
+} // namespace NKikimr

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
@@ -43,6 +43,7 @@ namespace NKikimr {
         void SetStatusFlags(NKikimrBlobStorage::TPDiskSpaceColor::E spaceColor);
         void SetStatusFlags(NPDisk::TStatusFlags flags);
         TString& GetStateErrorReason();
+        ui32 GetNumActiveSlots() const;
 
         TPtr Snapshot(); // create a copy of PDisk whole state
 

--- a/ydb/core/blobstorage/pdisk/ut/ya.make
+++ b/ydb/core/blobstorage/pdisk/ut/ya.make
@@ -42,6 +42,7 @@ SRCS(
     blobstorage_pdisk_ut_run.cpp
     blobstorage_pdisk_ut_sectormap.cpp
     blobstorage_pdisk_util_ut.cpp
+    blobstorage_pdisk_ut_pdisk_config.cpp
     blobstorage_pdisk_ut_chunk_tracker.cpp
     mock/pdisk_mock.cpp
 )

--- a/ydb/core/blobstorage/ut_blobstorage/group_size_in_units.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/group_size_in_units.cpp
@@ -1,0 +1,111 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/common.h>
+
+Y_UNIT_TEST_SUITE(GroupSizeInUnits) {
+
+    using namespace NKikimrBlobStorage;
+
+    Y_UNIT_TEST(SimplestErasureNone) {
+        TEnvironmentSetup env({
+            .NodeCount = 1,
+            .Erasure = TBlobStorageGroupType::ErasureNone,
+        });
+
+        for (ui32 nodeId : env.Runtime->GetNodes()) {
+            TActorId whiteboardId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(nodeId);
+            TActorId whiteboardActor = env.Runtime->Register(NNodeWhiteboard::CreateNodeWhiteboardService(), nodeId);
+            env.Runtime->RegisterService(whiteboardId, whiteboardActor);
+        }
+
+        // Init: 1 group, 1 vdisk, 1 pdisk
+        env.CreateBoxAndPool(1, 1);
+        env.Sim(TDuration::Minutes(1));
+        UNIT_ASSERT_VALUES_EQUAL(env.PDiskMockStates.size(), 1);
+        const TPDiskMockState& pdiskMockState = *env.PDiskMockStates.begin()->second;
+        UNIT_ASSERT_VALUES_EQUAL(pdiskMockState.GetNumActiveSlots(), 1);
+
+        // Fetch BaseConfig
+        TBaseConfig baseConfig_rev1 = env.FetchBaseConfig();
+
+        // Validate BaseConfig.PDisk.Config.SlotSizeInUnits
+        UNIT_ASSERT_VALUES_EQUAL(baseConfig_rev1.PDiskSize(), 1);
+        const TBaseConfig_TPDisk& pdiskBaseConfig = baseConfig_rev1.GetPDisk(0);
+        const ui32 nodeId = pdiskBaseConfig.GetNodeId();
+        const ui32 pdiskId = pdiskBaseConfig.GetPDiskId();
+        UNIT_ASSERT_VALUES_EQUAL(pdiskBaseConfig.GetPDiskConfig().GetSlotSizeInUnits(), 0u);
+
+        {
+            // Validate BaseConfig.Group.GroupSizeInUnits
+            auto groups = env.GetGroups();
+            UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
+            auto groupInfo = env.GetGroupInfo(groups[0]);
+            UNIT_ASSERT_VALUES_EQUAL(groupInfo->GroupGeneration, 1);
+            UNIT_ASSERT_VALUES_EQUAL(groupInfo->GroupSizeInUnits, 0u);
+
+            // Validate BaseConfig.VSlot.GroupSizeInUnits
+            UNIT_ASSERT_VALUES_EQUAL(baseConfig_rev1.VSlotSize(), 1);
+            const TBaseConfig_TVSlot& vslotBaseConfig = baseConfig_rev1.GetVSlot(0);
+            const NKikimrBlobStorage::TVSlotId vslotId = vslotBaseConfig.GetVSlotId();
+            UNIT_ASSERT_VALUES_EQUAL(vslotId.GetNodeId(), nodeId);
+            UNIT_ASSERT_VALUES_EQUAL(vslotId.GetPDiskId(), pdiskId);
+            UNIT_ASSERT_VALUES_EQUAL(vslotBaseConfig.GetGroupId(), groupInfo->GroupID.GetRawId());
+            UNIT_ASSERT_VALUES_EQUAL(vslotBaseConfig.GetGroupGeneration(), groupInfo->GroupGeneration);
+        }
+
+        {
+            // Reqest ReadStoragePool
+            NKikimrBlobStorage::TConfigRequest readStoragePoolRequest;
+            auto* cmd1 = readStoragePoolRequest.AddCommand()->MutableReadStoragePool();
+            cmd1->SetBoxId(1);
+            NKikimrBlobStorage::TConfigResponse readStoragePoolResponse = env.Invoke(readStoragePoolRequest);
+            UNIT_ASSERT_C(readStoragePoolResponse.GetSuccess(), readStoragePoolResponse.GetErrorDescription());
+            UNIT_ASSERT_C(readStoragePoolResponse.GetStatus(0).GetSuccess(), readStoragePoolResponse.GetStatus(0).GetErrorDescription());
+
+            UNIT_ASSERT_VALUES_EQUAL(readStoragePoolResponse.StatusSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(readStoragePoolResponse.GetStatus(0).StoragePoolSize(), 1);
+            const TDefineStoragePool storagePool = readStoragePoolResponse.GetStatus(0).GetStoragePool(0);
+            UNIT_ASSERT_VALUES_EQUAL(storagePool.GetDefaultGroupSizeInUnits(), 0u);
+
+            // Request DefineStoragePool DefaultGroupSizeInUnits# 2 NumGroups# 2
+            NKikimrBlobStorage::TConfigRequest defineStoragePoolRequest;
+            auto* cmd2 = defineStoragePoolRequest.AddCommand()->MutableDefineStoragePool();
+            cmd2->CopyFrom(storagePool);
+            cmd2->SetNumGroups(2);
+            cmd2->SetDefaultGroupSizeInUnits(2u);
+            cmd2->SetItemConfigGeneration(1);
+            NKikimrBlobStorage::TConfigResponse defineStoragePoolResponse = env.Invoke(defineStoragePoolRequest);
+            UNIT_ASSERT_C(defineStoragePoolResponse.GetSuccess(), defineStoragePoolResponse.GetErrorDescription());
+            UNIT_ASSERT_C(defineStoragePoolResponse.GetStatus(0).GetSuccess(), defineStoragePoolResponse.GetStatus(0).GetErrorDescription());
+            env.Sim(TDuration::Minutes(1));
+
+            // Validate NumActiveSlots
+            UNIT_ASSERT_VALUES_EQUAL(pdiskMockState.GetNumActiveSlots(), 3);
+        }
+
+        {
+            // Validate BaseConfig.Groups
+            auto groups = env.GetGroups();
+            UNIT_ASSERT_VALUES_EQUAL(groups.size(), 2);
+            auto group0 = env.GetGroupInfo(groups[0]);
+            UNIT_ASSERT_VALUES_EQUAL(group0->GroupGeneration, 1);
+            UNIT_ASSERT_VALUES_EQUAL(group0->GroupSizeInUnits, 0u);
+            auto group1 = env.GetGroupInfo(groups[1]);
+            UNIT_ASSERT_VALUES_EQUAL(group1->GroupGeneration, 1);
+            UNIT_ASSERT_VALUES_EQUAL(group1->GroupSizeInUnits, 2u);
+
+            // Validate BaseConfig.VSlot.GroupSizeInUnits
+            TBaseConfig baseConfig_rev2 = env.FetchBaseConfig();
+            UNIT_ASSERT_VALUES_EQUAL(baseConfig_rev2.VSlotSize(), 2);
+            THashMap<ui32, const TBaseConfig_TVSlot*> vslotsByGroupId;
+            for (size_t i = 0; i < baseConfig_rev2.VSlotSize(); ++i) {
+                const auto& vslot = baseConfig_rev2.GetVSlot(i);
+                vslotsByGroupId[vslot.GetGroupId()] = &vslot;
+            }
+
+            const auto* vslot0 = vslotsByGroupId.at(groups[0]);
+            UNIT_ASSERT_VALUES_EQUAL(vslot0->GetGroupGeneration(), group0->GroupGeneration);
+            const auto* vslot1 = vslotsByGroupId.at(groups[1]);
+            UNIT_ASSERT_VALUES_EQUAL(vslot1->GetGroupGeneration(), group1->GroupGeneration);
+        }
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -591,7 +591,7 @@ struct TEnvironmentSetup {
         UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
     }
 
-    void CreatePoolInBox(ui32 boxId, ui32 poolId, TString poolName) {
+    void CreatePoolInBox(ui32 boxId, ui32 poolId, TString poolName, ui32 defaultGroupSizeInUnits = 0) {
         NKikimrBlobStorage::TConfigRequest request;
 
         auto *cmd = request.AddCommand()->MutableDefineStoragePool();
@@ -602,6 +602,7 @@ struct TEnvironmentSetup {
         cmd->SetErasureSpecies(TBlobStorageGroupType::ErasureSpeciesName(Settings.Erasure.GetErasure()));
         cmd->SetVDiskKind("Default");
         cmd->SetNumGroups(1);
+        cmd->SetDefaultGroupSizeInUnits(defaultGroupSizeInUnits);
         cmd->AddPDiskFilter()->AddProperty()->SetType(NKikimrBlobStorage::EPDiskType::ROT);
         if (Settings.Encryption) {
             cmd->SetEncryptionMode(TBlobStorageGroupInfo::EEncryptionMode::EEM_ENC_V1);
@@ -674,7 +675,7 @@ struct TEnvironmentSetup {
                 for (const auto& [vdiskId, vdiskActorId] : vdisks) {
                     dyn.PushBackActorId(vdiskActorId);
                 }
-                return new TBlobStorageGroupInfo(std::move(topology), std::move(dyn), "storage_pool");
+                return new TBlobStorageGroupInfo(std::move(topology), std::move(dyn), "storage_pool", {}, NPDisk::DEVICE_TYPE_UNKNOWN, group.GetGroupSizeInUnits());
             }
         }
         return nullptr;

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -50,6 +50,7 @@ SRCS(
     ut_helpers.cpp
     validation.cpp
     vdisk_malfunction.cpp
+    group_size_in_units.cpp
 )
 
 PEERDIR(

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_public.cpp
@@ -600,7 +600,8 @@ namespace NKikimr {
 
         void SendYardInit(const TActorContext &ctx, TDuration yardInitDelay) {
             auto ev = std::make_unique<NPDisk::TEvYardInit>(Config->BaseInfo.InitOwnerRound, SelfVDiskId,
-                Config->BaseInfo.PDiskGuid, SkeletonId, SkeletonFrontId, Config->BaseInfo.VDiskSlotId);
+                Config->BaseInfo.PDiskGuid, SkeletonId, SkeletonFrontId,
+                Config->BaseInfo.VDiskSlotId, Config->GroupSizeInUnits);
             auto handle = std::make_unique<IEventHandle>(Config->BaseInfo.PDiskActorID, SelfId(), ev.release(),
                 IEventHandle::FlagTrackDelivery);
             if (yardInitDelay != TDuration::Zero()) {


### PR DESCRIPTION
### Changelog category

* Not for changelog

### Description for reviewers

- Follow-up for https://github.com/ydb-platform/ydb/pull/19160
- Part of #17357
- Related epic #16959
- RFC: https://github.com/ydb-platform/ydb-rfc/blob/main/156_pdisks_of_different_sizes.md

This PR includes the following changes:

- TEvYardInit now includes GroupSizeInUnits parameter
- PDisk copies it from YardInit to OwnerData
- OwnerData is persisted in `TPDisk::WriteSysLogRestorePoint` and loaded in `TPDisk::ProcessChunk0`
- Owner quota in TChunkTracker is calculated based on the weight obtained from `TPDiskConfig::GetOwnerWeight(groupSizeInUnits, slotSizeInUnits)`
- NumActiveSlots now returns the sum of owner weights
- Add unit test `TPDiskConfig::GetOwnerWeight`
- Add unit test `TChunkTrackerTest::AddOwnerWithWeight`
- Add tests `GroupSizeInUnits` with bscontroller, actor system, and mocked pdisks   
 